### PR TITLE
Fix duplicate consent task in testcas.sh

### DIFF
--- a/testcas.sh
+++ b/testcas.sh
@@ -189,7 +189,6 @@ while (( "$#" )); do
                 ;;
             consent)
                 task+="testConsent "
-                task+="testConsent "
                 ;;
             duo|duosecurity)
                 task+="testDuoSecurity "


### PR DESCRIPTION
## Summary
- remove duplicate call to `testConsent`

## Testing
- `./gradlew help` *(fails: No route to host)*