### PR TITLE
Fix printable characters for random generators

### DIFF
--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/gen/DefaultRandomNumberGenerator.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/gen/DefaultRandomNumberGenerator.java
@@ -8,7 +8,7 @@ package org.apereo.cas.util.gen;
  * @since 3.0.0
  */
 public class DefaultRandomNumberGenerator extends DefaultRandomStringGenerator {
-    private static final char[] PRINTABLE_CHARACTERS = "012345679".toCharArray();
+    private static final char[] PRINTABLE_CHARACTERS = "0123456789".toCharArray();
 
     public DefaultRandomNumberGenerator(final int defaultLength) {
         super(defaultLength);

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/gen/DefaultRandomStringGenerator.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/gen/DefaultRandomStringGenerator.java
@@ -18,7 +18,7 @@ public class DefaultRandomStringGenerator extends AbstractRandomStringGenerator 
     /**
      * The array of printable characters to be used in our random string.
      */
-    private static final char[] PRINTABLE_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ012345679".toCharArray();
+    private static final char[] PRINTABLE_CHARACTERS = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".toCharArray();
 
     public DefaultRandomStringGenerator(final long defaultLength) {
         super(defaultLength);


### PR DESCRIPTION
## Summary
- include digit `8` in printable characters

## Testing
- `./gradlew :core:cas-server-core-util-api:test` *(fails: `No route to host`)*
- `./gradlew :core:cas-server-core-util:test` *(fails: `No route to host`)*
