### PR TITLE
Replace sleep with Awaitility in SQS appender test

### DIFF
--- a/support/cas-server-support-logging-config-sqs/src/test/java/org/apereo/cas/logging/SQSAppenderTests.java
+++ b/support/cas-server-support-logging-config-sqs/src/test/java/org/apereo/cas/logging/SQSAppenderTests.java
@@ -7,9 +7,11 @@ import org.apache.logging.log4j.core.LoggerContext;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.stream.IntStream;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.awaitility.Awaitility.*;
 
 /**
  * This is {@link SQSAppenderTests}.
@@ -28,7 +30,7 @@ class SQSAppenderTests {
         assertNotNull(appender);
         assertDoesNotThrow(() -> IntStream.range(1, 20)
             .forEach(idx -> logger.info("Testing [{}]...", idx)));
-        Thread.sleep(5_000);
+        await().atMost(Duration.ofSeconds(5)).until(appender::isStopped);
         appender.stop();
     }
 }


### PR DESCRIPTION
## Summary
- remove Thread.sleep usage in the SQSAppender test
- wait until the appender is stopped using Awaitility

## Testing
- `./gradlew :support:cas-server-support-logging-config-sqs:test --no-daemon -q` *(fails: No route to host)*