### PR TITLE
Fix typo in ReflectionUtils JavaDoc

### DIFF
--- a/api/cas-server-core-api-util/src/main/java/org/apereo/cas/util/ReflectionUtils.java
+++ b/api/cas-server-core-api-util/src/main/java/org/apereo/cas/util/ReflectionUtils.java
@@ -45,7 +45,7 @@ public class ReflectionUtils {
     }
 
     /**
-     * Finds all classes in the given package, wich are annotated with at least one of the given annotations.
+     * Finds all classes in the given package, which are annotated with at least one of the given annotations.
      *
      * @param annotations The annotations to look for.
      * @param packageName The base package to look in.


### PR DESCRIPTION
## Summary
- fix typo in `findClassesWithAnnotationsInPackage` JavaDoc

## Testing
- `./gradlew projects` *(fails: Downloading from https://services.gradle.org/distributions/gradle-8.14-bin.zip failed: timeout)*