### PR TITLE
Fix generic type for MockWebServer

### DIFF
--- a/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/MockWebServer.java
+++ b/core/cas-server-core-util-api/src/test/java/org/apereo/cas/util/MockWebServer.java
@@ -50,7 +50,7 @@ public class MockWebServer implements Closeable {
     private static final int STARTING_PORT_RANGE = 4000;
     private static final int ENDING_PORT_RANGE = 9999;
 
-    private static final ConcurrentSkipListSet ALL_PORTS = new ConcurrentSkipListSet<>();
+    private static final ConcurrentSkipListSet<Integer> ALL_PORTS = new ConcurrentSkipListSet<>();
     private static final ObjectMapper MAPPER = JacksonObjectMapperFactory.builder()
         .defaultTypingEnabled(true).build().toObjectMapper();
 


### PR DESCRIPTION
## Summary
- use `ConcurrentSkipListSet<Integer>` for ALL_PORTS in MockWebServer

## Testing
- `./gradlew :core:cas-server-core-util-api:compileTestJava` *(fails: No route to host)*