### PR TITLE
Fix acme challenge test

### DIFF
--- a/support/cas-server-support-acme/src/test/java/org/apereo/cas/acme/AcmeChallengeRepositoryTests.java
+++ b/support/cas-server-support-acme/src/test/java/org/apereo/cas/acme/AcmeChallengeRepositoryTests.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.awaitility.Awaitility.*;
 
 /**
  * This is {@link AcmeChallengeRepositoryTests}.
@@ -21,8 +22,7 @@ class AcmeChallengeRepositoryTests extends BaseAcmeTests {
     void verifyOperation() throws Throwable {
         acmeChallengeRepository.add("token", "challenge");
         assertNotNull(acmeChallengeRepository.get("token"));
-        Thread.sleep(3000);
-        assertNull(acmeChallengeRepository.get("token"));
+        await().untilAsserted(() -> assertNull(acmeChallengeRepository.get("token")));
     }
 
 }


### PR DESCRIPTION
## Summary
- replace Thread.sleep with Awaitility in `AcmeChallengeRepositoryTests`

## Testing
- `./gradlew :support:cas-server-support-acme:test` *(fails: Could not download Gradle due to no network)*