### PR TITLE
Fix typos across repository

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/sms/RestfulSmsProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/sms/RestfulSmsProperties.java
@@ -24,7 +24,7 @@ public class RestfulSmsProperties extends RestEndpointProperties {
     private static final long serialVersionUID = -8102345678378393382L;
 
     /**
-     * Indicate the style and formatting of the SMS request paramerters
+     * Indicate the style and formatting of the SMS request parameters
      * and how they should be included and sent via REST.
      */
     private RestfulSmsRequestStyles style = RestfulSmsRequestStyles.QUERY_PARAMETERS;

--- a/api/cas-server-core-api-webflow/src/main/java/org/apereo/cas/web/flow/CasWebflowConstants.java
+++ b/api/cas-server-core-api-webflow/src/main/java/org/apereo/cas/web/flow/CasWebflowConstants.java
@@ -1751,9 +1751,9 @@ public interface CasWebflowConstants {
     String ACTION_ID_RENEW_AUTHN_REQUEST = "renewAuthenticationRequestCheckAction";
 
     /**
-     * Action id 'negociateSpnego'.
+     * Action id 'negotiateSpnego'.
      */
-    String ACTION_ID_SPNEGO_NEGOTIATE = "negociateSpnego";
+    String ACTION_ID_SPNEGO_NEGOTIATE = "negotiateSpnego";
 
     /**
      * Action id 'acceptableUsagePolicyVerifyAction.

--- a/ci/tests/cassandra/cassandra.yaml
+++ b/ci/tests/cassandra/cassandra.yaml
@@ -283,7 +283,7 @@ commit_failure_policy: stop
 # i.e. use bind markers for variable parts.
 #
 # Do only change the default value, if you really have more prepared statements than
-# fit in the cache. In most cases it is not neccessary to change this value.
+# fit in the cache. In most cases it is not necessary to change this value.
 # Constantly re-preparing statements is a performance penalty.
 #
 # Default value ("auto") is 1/256th of the heap or 10MB, whichever is greater

--- a/core/cas-server-core-configuration/src/test/resources/directory/application.yml
+++ b/core/cas-server-core-configuration/src/test/resources/directory/application.yml
@@ -5,4 +5,4 @@ test:
     cas: dirAppYml
   file: dirAppYml
   profile: dirAppYml
-  overriden-by-system-property: from-application-yml
+  overridden-by-system-property: from-application-yml

--- a/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/config/SpnegoWebflowActionsConfiguration.java
+++ b/support/cas-server-support-spnego-webflow/src/main/java/org/apereo/cas/config/SpnegoWebflowActionsConfiguration.java
@@ -73,7 +73,7 @@ class SpnegoWebflowActionsConfiguration {
     @Bean
     @RefreshScope(proxyMode = ScopedProxyMode.DEFAULT)
     @ConditionalOnMissingBean(name = CasWebflowConstants.ACTION_ID_SPNEGO_NEGOTIATE)
-    public Action negociateSpnego(
+    public Action negotiateSpnego(
         final ConfigurableApplicationContext applicationContext,
         final CasConfigurationProperties casProperties) {
         return WebflowActionBeanSupplier.builder()

--- a/support/cas-server-support-spnego-webflow/src/test/java/org/apereo/cas/web/flow/AbstractSpnegoTests.java
+++ b/support/cas-server-support-spnego-webflow/src/test/java/org/apereo/cas/web/flow/AbstractSpnegoTests.java
@@ -55,8 +55,8 @@ import org.springframework.webflow.execution.Action;
 public abstract class AbstractSpnegoTests {
 
     @Autowired
-    @Qualifier("negociateSpnego")
-    protected Action negociateSpnegoAction;
+    @Qualifier("negotiateSpnego")
+    protected Action negotiateSpnegoAction;
 
     @Autowired
     @Qualifier("spnego")

--- a/support/cas-server-support-spnego-webflow/src/test/java/org/apereo/cas/web/flow/SpnegoNegotiateCredentialsActionTests.java
+++ b/support/cas-server-support-spnego-webflow/src/test/java/org/apereo/cas/web/flow/SpnegoNegotiateCredentialsActionTests.java
@@ -20,7 +20,7 @@ class SpnegoNegotiateCredentialsActionTests extends AbstractSpnegoTests {
     @Test
     void verifyOperation() throws Throwable {
         val context = MockRequestContext.create(applicationContext).withUserAgent("MSIE");
-        negociateSpnegoAction.execute(context);
+        negotiateSpnegoAction.execute(context);
         assertNotNull(context.getHttpServletResponse().getHeader(SpnegoConstants.HEADER_AUTHENTICATE));
         assertEquals(HttpServletResponse.SC_UNAUTHORIZED, context.getHttpServletResponse().getStatus());
     }
@@ -28,15 +28,15 @@ class SpnegoNegotiateCredentialsActionTests extends AbstractSpnegoTests {
     @Test
     void verifyEmptyAgent() throws Throwable {
         val context = MockRequestContext.create(applicationContext);
-        assertEquals(CasWebflowConstants.TRANSITION_ID_ERROR, negociateSpnegoAction.execute(context).getId());
+        assertEquals(CasWebflowConstants.TRANSITION_ID_ERROR, negotiateSpnegoAction.execute(context).getId());
         context.withUserAgent();
-        assertEquals(CasWebflowConstants.TRANSITION_ID_ERROR, negociateSpnegoAction.execute(context).getId());
+        assertEquals(CasWebflowConstants.TRANSITION_ID_ERROR, negotiateSpnegoAction.execute(context).getId());
     }
 
     @Test
     void verifyBadAuthzHeader() throws Throwable {
         val context = MockRequestContext.create(applicationContext).withUserAgent("Firefox");
         context.addHeader(HttpHeaders.AUTHORIZATION, SpnegoConstants.NEGOTIATE + " XYZ");
-        assertEquals(CasWebflowConstants.TRANSITION_ID_SUCCESS, negociateSpnegoAction.execute(context).getId());
+        assertEquals(CasWebflowConstants.TRANSITION_ID_SUCCESS, negotiateSpnegoAction.execute(context).getId());
     }
 }

--- a/support/cas-server-support-x509-core/etc/testCA/openssl.cnf
+++ b/support/cas-server-support-x509-core/etc/testCA/openssl.cnf
@@ -38,7 +38,7 @@ crl		= $dir/crl.pem 		# The current CRL
 private_key	= $dir/private/cakey.pem # The private key
 RANDFILE	= $dir/private/.rand	# private random number file
 
-x509_extensions	= usr_cert		# The extentions to add to the cert
+x509_extensions	= usr_cert		# The extensions to add to the cert
 
 name_opt 	= ca_default		# Subject Name options
 cert_opt 	= ca_default		# Certificate field options
@@ -68,7 +68,7 @@ crl		= $dir/crl.pem 		# The current CRL
 private_key	= $dir/private/cakey.pem # The private key
 RANDFILE	= $dir/private/.rand	# private random number file
 
-x509_extensions	= usr_cert		# The extentions to add to the cert
+x509_extensions	= usr_cert		# The extensions to add to the cert
 
 name_opt 	= ca_default		# Subject Name options
 cert_opt 	= ca_default		# Certificate field options
@@ -99,7 +99,7 @@ crl		= $dir/crl.pem 		# The current CRL
 private_key	= $dir/private/cakey.pem # The private key
 RANDFILE	= $dir/private/.rand	# private random number file
 
-x509_extensions	= usr_cert		# The extentions to add to the cert
+x509_extensions	= usr_cert		# The extensions to add to the cert
 
 name_opt 	= ca_default		# Subject Name options
 cert_opt 	= ca_default		# Certificate field options
@@ -135,7 +135,7 @@ default_bits		= 2048
 default_keyfile 	= privkey.pem
 distinguished_name	= req_distinguished_name
 attributes		= req_attributes
-x509_extensions	= v3_ca	# The extentions to add to the self signed cert
+x509_extensions	= v3_ca	# The extensions to add to the self signed cert
 
 # This sets a mask for permitted string types. There are several options. 
 # default: PrintableString, T61String, BMPString.


### PR DESCRIPTION
## Summary
- correct multiple spelling errors in cassandra.yaml
- fix 'extentions' in openssl.cnf
- rename negociateSpnego references to negotiateSpnego
- fix spelling in RestfulSmsProperties
- correct test application.yml property key

## Testing
- `./gradlew :support:cas-server-support-spnego-webflow:testClasses -q` *(fails: No route to host)*