### PR TITLE
Fix documentation typos

### DIFF
--- a/docs/cas-server-documentation/configuration/Configuration-Management-Extensions.md
+++ b/docs/cas-server-documentation/configuration/Configuration-Management-Extensions.md
@@ -73,7 +73,7 @@ What if you needed to override the definition of a CAS-provided bean and replace
 This is where `@Conditional` components come to aid. Most component/bean definitions in CAS are registered 
 with some form of `@Conditional` tag that indicates to the bootstrapping process to ignore their 
 creation, if *a bean definition with the same id* is already defined. This means you can create 
-your own configuration class, register it and the design a `@Bean` definition only to have the 
+your own configuration class, register it and then design a `@Bean` definition only to have the
 context utilize yours rather than what ships with CAS by default.
 
 <div class="alert alert-info">:information_source: <strong>Bean Names</strong><p>To correctly define a conditional <code>Bean</code>, 

--- a/docs/cas-server-documentation/installation/WAR-Overlay-Installation.md
+++ b/docs/cas-server-documentation/installation/WAR-Overlay-Installation.md
@@ -26,7 +26,7 @@ installation process will attempt to download the provided
 binary artifact first. Then the tool will locate your configuration files and settings made available 
 inside the same project directory and will merge those into the downloaded artifact in order to produce
 one wholesome archive (i.e. `cas.war`) . Overridden artifacts may include 
-resources, java classes, images, CSS and javascript files. In order for the merge
+resources, java classes, images, CSS and JavaScript files. In order for the merge
 process to successfully execute, the location and names of the overridden artifacts 
 locally must **EXACTLY** match that of those provided by the project
 inside the originally downloaded archive. Java code in the overlay project's `src/main/java` 

--- a/docs/cas-server-documentation/integration/Attribute-Resolution-JDBC.md
+++ b/docs/cas-server-documentation/integration/Attribute-Resolution-JDBC.md
@@ -55,15 +55,15 @@ authenticates via `sAMAccountName`.
 
 ## Example #1
 
-If the resolver is configured to use `sAMAccoutName` as the attribute for the principal id, then when authentication is complete the resolver attempts
-to construct attributes from attribute repository sources, it sees `sAMAccoutName` as the attribute and sees the principal id is to
-be created by `sAMAccoutName`. So it would remove the `sAMAccoutName` from the attributes.
+If the resolver is configured to use `sAMAccountName` as the attribute for the principal id, then when authentication is complete the resolver attempts
+to construct attributes from attribute repository sources, it sees `sAMAccountName` as the attribute and sees the principal id is to
+be created by `sAMAccountName`. So it would remove the `sAMAccountName` from the attributes.
 The final result is a principal whose id is `johnsmith` who has a `cn` attribute of `John Smith`.
 
 ## Example #2
 
 If the resolver is configured to use `cn` as the attribute for the principal id, then when authentication is complete the resolver attempts to
-construct attributes from attribute repository sources. It then sees `sAMAccoutName` as the attribute and sees the principal id is to be created by `cn`.
+construct attributes from attribute repository sources. It then sees `sAMAccountName` as the attribute and sees the principal id is to be created by `cn`.
 So it would remove the `cn` from the attributes. The final result is a principal whose id is `John Smith`
 who has a `sAMAccountName` attribute of `johnsmith`.
 

--- a/docs/cas-server-documentation/monitoring/Configuring-Monitoring-AzureInsights.md
+++ b/docs/cas-server-documentation/monitoring/Configuring-Monitoring-AzureInsights.md
@@ -27,7 +27,7 @@ The following considerations apply to the agent:
 
 - JRE distributions are not supported.
 - The temporary directory of the operating system should be writable.
-- Spring's `application.properties` or `application.yaml` files are not supported as as sources for Application Insights configuration.
+- Spring's `application.properties` or `application.yaml` files are not supported as sources for Application Insights configuration.
 
 By default the configuration file `applicationinsights.json` is read from the 
 classpath from `src/main/resources`. You can configure the name of the JSON file in the classpath with the


### PR DESCRIPTION
## Summary
- correct grammar in configuration management docs
- tweak wording in WAR overlay install docs
- fix duplication in Azure Insights doc
- correct attribute name in JDBC integration doc

## Testing
- `jekyll build` *(fails: command not found)*
- `./gradlew :docs:tasks --all` *(fails: No route to host)*