### PR TITLE
Fix ScriptingUtils input stream handling

### DIFF
--- a/core/cas-server-core-scripting/src/main/java/org/apereo/cas/util/scripting/ScriptingUtils.java
+++ b/core/cas-server-core-scripting/src/main/java/org/apereo/cas/util/scripting/ScriptingUtils.java
@@ -487,8 +487,9 @@ public class ScriptingUtils {
                 LOGGER.debug("No groovy script is defined");
                 return null;
             }
-            val script = IOUtils.toString(resource.getInputStream(), StandardCharsets.UTF_8);
-            try (val classLoader = ScriptingUtils.newGroovyClassLoader()) {
+            try (val inputStream = resource.getInputStream();
+                 val classLoader = ScriptingUtils.newGroovyClassLoader()) {
+                val script = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
                 val clazz = classLoader.parseClass(script);
                 LOGGER.trace("Preparing constructor arguments [{}] for resource [{}]", args, resource);
                 val ctor = clazz.getDeclaredConstructor(constructorArgs);


### PR DESCRIPTION
## Summary
- close Groovy script resources with try-with-resources

## Testing
- `gradle :core:cas-server-core-scripting:compileJava` *(fails: Plugin com.gradle.develocity not found)*
- `gradle :core:cas-server-core-scripting:test` *(fails: Plugin com.gradle.develocity not found)*