### PR TITLE
Update JS customization docs for clarity

### DIFF
--- a/docs/cas-server-documentation/ux/User-Interface-Customization-CSSJS.md
+++ b/docs/cas-server-documentation/ux/User-Interface-Customization-CSSJS.md
@@ -33,9 +33,9 @@ same `cas.css` file. They follow the Twitter Bootstrap breakpoints and grid.
 
 # JavaScript
 
-If you need to add some JavaScript, feel free to append `src/main/resources/static/js/cas.js`.
+If you need to add some JavaScript, feel free to append to `src/main/resources/static/js/cas.js`.
 
-You can also create your own custom javascript file, for example, and call it from within `scripts.html` like so:
+You can also create your own custom JavaScript file and include it in `scripts.html` like so:
 
 ```html
 <script type="text/javascript" src="/js/my.js"></script>


### PR DESCRIPTION
## Summary
- fix casing of 'JavaScript' in the UI customization docs
- clarify how to include custom JavaScript files

## Testing
- `./gradlew test --quiet` *(fails: No route to host)*