### PR TITLE
Fix stream closing in SAML IdP metadata controller

### DIFF
--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/metadata/SamlIdPMetadataController.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/metadata/SamlIdPMetadataController.java
@@ -64,14 +64,15 @@ public class SamlIdPMetadataController {
 
         val registeredService = getRegisteredServiceIfAny(service);
         metadataAndCertificatesGenerationService.generate(registeredService);
-        val md = samlIdPMetadataLocator.resolveMetadata(registeredService).getInputStream();
-        val contents = IOUtils.toString(md, StandardCharsets.UTF_8);
         response.setContentType(CONTENT_TYPE);
         response.setStatus(HttpServletResponse.SC_OK);
-        try (val writer = response.getWriter()) {
-            LOGGER.debug("Producing metadata for the response");
-            writer.write(contents);
-            writer.flush();
+        try (val md = samlIdPMetadataLocator.resolveMetadata(registeredService).getInputStream()) {
+            val contents = IOUtils.toString(md, StandardCharsets.UTF_8);
+            try (val writer = response.getWriter()) {
+                LOGGER.debug("Producing metadata for the response");
+                writer.write(contents);
+                writer.flush();
+            }
         }
     }
 
@@ -88,8 +89,9 @@ public class SamlIdPMetadataController {
         @RequestParam(value = "service", required = false) final String service) throws Throwable {
         val registeredService = getRegisteredServiceIfAny(service);
         metadataAndCertificatesGenerationService.generate(registeredService);
-        val md = samlIdPMetadataLocator.resolveSigningCertificate(registeredService).getInputStream();
-        return IOUtils.toString(md, StandardCharsets.UTF_8);
+        try (val md = samlIdPMetadataLocator.resolveSigningCertificate(registeredService).getInputStream()) {
+            return IOUtils.toString(md, StandardCharsets.UTF_8);
+        }
     }
 
     /**
@@ -105,8 +107,9 @@ public class SamlIdPMetadataController {
         @RequestParam(value = "service", required = false) final String service) throws Throwable {
         val registeredService = getRegisteredServiceIfAny(service);
         metadataAndCertificatesGenerationService.generate(registeredService);
-        val md = samlIdPMetadataLocator.resolveEncryptionCertificate(registeredService).getInputStream();
-        return IOUtils.toString(md, StandardCharsets.UTF_8);
+        try (val md = samlIdPMetadataLocator.resolveEncryptionCertificate(registeredService).getInputStream()) {
+            return IOUtils.toString(md, StandardCharsets.UTF_8);
+        }
     }
 
     private Optional<SamlRegisteredService> getRegisteredServiceIfAny(final String service) {


### PR DESCRIPTION
## Summary
- close metadata input streams with try-with-resources in `SamlIdPMetadataController`

## Testing
- `gradle :support:cas-server-support-saml-idp-web:clean :support:cas-server-support-saml-idp-web:build` *(fails: Plugin was not found)*