### PR TITLE
Fix Application Insights docs note

### DIFF
--- a/docs/cas-server-documentation/monitoring/Configuring-Monitoring-AzureInsights.md
+++ b/docs/cas-server-documentation/monitoring/Configuring-Monitoring-AzureInsights.md
@@ -27,7 +27,7 @@ The following considerations apply to the agent:
 
 - JRE distributions are not supported.
 - The temporary directory of the operating system should be writable.
-- Spring's `application.properties` or `application.yaml` files are not supported as as sources for Application Insights configuration.
+- Spring’s `application.properties` or `application.yaml` files are not supported as sources for Application Insights configuration.
 
 By default the configuration file `applicationinsights.json` is read from the 
 classpath from `src/main/resources`. You can configure the name of the JSON file in the classpath with the


### PR DESCRIPTION
## Summary
- fix bullet about Application Insights configuration

## Testing
- `ci/docs/publish.sh --publish false --skip-clone true --build true --proof-read false` *(fails: unable to download Gradle wrapper)*
- `./gradlew :docs:cas-server-documentation-processor:build --console=plain` *(fails: No route to host)*