### PR TITLE
Fix CAS client protocols text

### DIFF
--- a/docs/cas-server-documentation/integration/CAS-Clients.md
+++ b/docs/cas-server-documentation/integration/CAS-Clients.md
@@ -9,7 +9,7 @@ category: Integration
 # Overview
 
 A CAS client is also a software package that can be integrated with various software platforms and applications in order to 
-communicate with the CAS server using or or more supported protocols. CAS clients 
+communicate with the CAS server using one or more supported protocols. CAS clients
 supporting a number of software platforms and products have been developed.
 
 


### PR DESCRIPTION
## Summary
- fix a typo in CAS client overview

## Testing
- `grep -n "one or more supported protocols" -n docs/cas-server-documentation/integration/CAS-Clients.md`
