### PR TITLE
Fix typo in encrypted attribute release doc

### DIFF
--- a/docs/cas-server-documentation/integration/Attribute-Release-Policy-ReturnEncrypted.md
+++ b/docs/cas-server-documentation/integration/Attribute-Release-Policy-ReturnEncrypted.md
@@ -8,7 +8,7 @@ category: Attributes
 
 # Attribute Release Policy - Return Encrypted
 
-Encrypt and encode all all allowed attributes in base-64 using the assigned registered service public key.
+Encrypt and encode all allowed attributes in base-64 using the assigned registered service public key.
 
 ```json
 {


### PR DESCRIPTION
## Summary
- fix duplicate word in Attribute-Release-Policy-ReturnEncrypted doc

## Testing
- `./gradlew --version` *(fails: timeout downloading gradle)*
- `./testcas.sh --help`