### PR TITLE
Fix InputStream handling in tickets API

### DIFF
--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/pubsub/MessageQueueMessageSerializationHandler.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/registry/pubsub/MessageQueueMessageSerializationHandler.java
@@ -43,7 +43,9 @@ public class MessageQueueMessageSerializationHandler implements Serializer<Objec
     @Nonnull
     @Override
     public BaseMessageQueueCommand deserialize(final InputStream inputStream) throws IOException {
-        return deserializeFromByteArray(inputStream.readAllBytes());
+        try (inputStream) {
+            return deserializeFromByteArray(inputStream.readAllBytes());
+        }
     }
 
     @Nonnull


### PR DESCRIPTION
## Summary
- ensure MessageQueueMessageSerializationHandler closes InputStream

## Testing
- `gradle :core:cas-server-core-tickets-api:build` *(fails: Plugin `com.gradle.develocity` could not be resolved)*
- `gradle :core:cas-server-core-tickets-api:test` *(fails: Plugin `com.gradle.develocity` could not be resolved)*