### PR TITLE
Fix resource handling in service definition loader

### DIFF
--- a/support/cas-server-support-palantir/src/main/java/org/apereo/cas/palantir/controller/DashboardController.java
+++ b/support/cas-server-support-palantir/src/main/java/org/apereo/cas/palantir/controller/DashboardController.java
@@ -83,10 +83,12 @@ public class DashboardController {
         val resources = resolver.getResources("classpath:service-definitions/**/*.json");
 
         for (val resource : resources) {
-            val contents = new String(FileCopyUtils.copyToByteArray(resource.getInputStream()), StandardCharsets.UTF_8);
-            val definition = serializer.from(contents);
-            if (definition != null) {
-                jsonFilesMap.computeIfAbsent(definition.getFriendlyName(), __ -> new ArrayList<>()).add(contents);
+            try (val inputStream = resource.getInputStream()) {
+                val contents = new String(FileCopyUtils.copyToByteArray(inputStream), StandardCharsets.UTF_8);
+                val definition = serializer.from(contents);
+                if (definition != null) {
+                    jsonFilesMap.computeIfAbsent(definition.getFriendlyName(), __ -> new ArrayList<>()).add(contents);
+                }
             }
         }
         return jsonFilesMap;


### PR DESCRIPTION
## Summary
- close InputStreams when loading JSON service definitions

## Testing
- `gradle --no-daemon :support:cas-server-support-palantir:build` *(fails: Plugin [id: 'com.gradle.develocity', version: '4.0.1'] was not found)*