### PR TITLE
Fix stream handling and update docs

### DIFF
--- a/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/web/CasEventsReportEndpoint.java
+++ b/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/web/CasEventsReportEndpoint.java
@@ -133,10 +133,12 @@ public class CasEventsReportEndpoint extends BaseCasRestActuatorEndpoint {
     }
 
     private ResponseEntity<CasEvent> importSingleEvent(final HttpServletRequest request) throws Throwable {
-        val requestBody = IOUtils.toString(request.getInputStream(), StandardCharsets.UTF_8);
-        val casEvent = MAPPER.readValue(requestBody, CasEvent.class);
-        eventRepository.getObject().save(casEvent);
-        return ResponseEntity.ok().build();
+        try (val in = request.getInputStream()) {
+            val requestBody = IOUtils.toString(in, StandardCharsets.UTF_8);
+            val casEvent = MAPPER.readValue(requestBody, CasEvent.class);
+            eventRepository.getObject().save(casEvent);
+            return ResponseEntity.ok().build();
+        }
     }
 
     private ResponseEntity<CasEvent> importEventsAsStream(final HttpServletRequest request) throws Throwable {

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/executor/EncryptedTranscoder.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/executor/EncryptedTranscoder.java
@@ -50,16 +50,17 @@ public class EncryptedTranscoder implements Transcoder {
         if (o == null) {
             return ArrayUtils.EMPTY_BYTE_ARRAY;
         }
-        val outBuffer = new ByteArrayOutputStream();
-        try (val out = this.compression
-            ? new ObjectOutputStream(new GZIPOutputStream(outBuffer))
-            : new ObjectOutputStream(outBuffer)) {
+        try (val outBuffer = new ByteArrayOutputStream();
+             val out = this.compression
+                 ? new ObjectOutputStream(new GZIPOutputStream(outBuffer))
+                 : new ObjectOutputStream(outBuffer)) {
 
             writeObjectToOutputStream(o, out);
+            return encrypt(outBuffer);
         } catch (final NotSerializableException e) {
             LoggingUtils.warn(LOGGER, e);
+            return ArrayUtils.EMPTY_BYTE_ARRAY;
         }
-        return encrypt(outBuffer);
     }
 
     @Override

--- a/docs/cas-server-documentation/authentication/OIDC-Authentication-Identity-Assurance.md
+++ b/docs/cas-server-documentation/authentication/OIDC-Authentication-Identity-Assurance.md
@@ -117,7 +117,7 @@ payload might be:
 
 If you wish to design your own source of identity assurance verifications, you
 may plug in a custom implementation of the `AssuranceVerificationSource` that
-allows you to handle this on on your own:
+allows you to handle this on your own:
 
 ```java
 @Bean

--- a/docs/cas-server-documentation/installation/Logout-Single-Signout.md
+++ b/docs/cas-server-documentation/installation/Logout-Single-Signout.md
@@ -106,7 +106,7 @@ Logout requests may be optionally routed to an external URL bypassing the CAS lo
 
 Registered applications with CAS have the option to control single logout behavior individually via
 the [Service Management](../services/Service-Management.html) component. Each registered service in the service registry will include configuration
-that describes how to the logout request should be submitted. This behavior is controlled via the `logoutType` property
+that describes how the logout request should be submitted. This behavior is controlled via the `logoutType` property
 which allows one to specify whether the logout request should be submitted via back/front channel or turned off for this application.
 
 Sample configuration follows:

--- a/docs/cas-server-documentation/webflow/Webflow-Customization-Interrupt-Tracking.md
+++ b/docs/cas-server-documentation/webflow/Webflow-Customization-Interrupt-Tracking.md
@@ -29,7 +29,7 @@ overall size of the cookie accepted by the browser or the server container of ch
  
 If you wish to design your own interrupt tracking mechanism, you
 may plug in a custom implementation of the `InterruptTrackingEngine` that
-allows you to handle this on on your own:
+allows you to handle this on your own:
                 
 ```java
 @Bean

--- a/support/cas-server-support-oauth-api/src/main/java/org/apereo/cas/ticket/device/OAuth20DeviceUserCodeFactory.java
+++ b/support/cas-server-support-oauth-api/src/main/java/org/apereo/cas/ticket/device/OAuth20DeviceUserCodeFactory.java
@@ -12,7 +12,7 @@ import org.apereo.cas.ticket.TicketFactory;
 public interface OAuth20DeviceUserCodeFactory extends TicketFactory {
 
     /**
-     * Create device user.
+     * Create OAuth 2.0 device user code.
      *
      * @param service the service
      * @return the device user code
@@ -22,11 +22,11 @@ public interface OAuth20DeviceUserCodeFactory extends TicketFactory {
     }
 
     /**
-     * Create device user code oauth device user code.
+     * Create OAuth 2.0 device user code.
      *
      * @param id      the id
      * @param service the service
-     * @return the oauth device user code
+     * @return the OAuth device user code
      */
     OAuth20DeviceUserCode createDeviceUserCode(String id, Service service);
 

--- a/support/cas-server-support-palantir/src/main/java/org/apereo/cas/palantir/controller/DashboardController.java
+++ b/support/cas-server-support-palantir/src/main/java/org/apereo/cas/palantir/controller/DashboardController.java
@@ -83,10 +83,12 @@ public class DashboardController {
         val resources = resolver.getResources("classpath:service-definitions/**/*.json");
 
         for (val resource : resources) {
-            val contents = new String(FileCopyUtils.copyToByteArray(resource.getInputStream()), StandardCharsets.UTF_8);
-            val definition = serializer.from(contents);
-            if (definition != null) {
-                jsonFilesMap.computeIfAbsent(definition.getFriendlyName(), __ -> new ArrayList<>()).add(contents);
+            try (val input = resource.getInputStream()) {
+                val contents = new String(FileCopyUtils.copyToByteArray(input), StandardCharsets.UTF_8);
+                val definition = serializer.from(contents);
+                if (definition != null) {
+                    jsonFilesMap.computeIfAbsent(definition.getFriendlyName(), __ -> new ArrayList<>()).add(contents);
+                }
             }
         }
         return jsonFilesMap;


### PR DESCRIPTION
## Summary
- close streams when loading dashboard resources
- ensure EncryptedTranscoder closes its output buffer
- close request stream when importing single events
- clarify OAuth device user code Javadocs
- fix grammatical issues in interrupt tracking, identity assurance, and logout docs

## Testing
- `./gradlew :support:cas-server-support-palantir:compileJava :core:cas-server-core-webflow-api:compileJava :core:cas-server-core-events-api:compileJava :support:cas-server-support-oauth-api:compileJava` *(fails: No route to host)*