### PR TITLE
Fix leaks in OIDC controllers and documentation typos

### DIFF
--- a/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/web/CasEventsReportEndpoint.java
+++ b/core/cas-server-core-events-api/src/main/java/org/apereo/cas/support/events/web/CasEventsReportEndpoint.java
@@ -133,10 +133,12 @@ public class CasEventsReportEndpoint extends BaseCasRestActuatorEndpoint {
     }
 
     private ResponseEntity<CasEvent> importSingleEvent(final HttpServletRequest request) throws Throwable {
-        val requestBody = IOUtils.toString(request.getInputStream(), StandardCharsets.UTF_8);
-        val casEvent = MAPPER.readValue(requestBody, CasEvent.class);
-        eventRepository.getObject().save(casEvent);
-        return ResponseEntity.ok().build();
+        try (val in = request.getInputStream()) {
+            val requestBody = IOUtils.toString(in, StandardCharsets.UTF_8);
+            val casEvent = MAPPER.readValue(requestBody, CasEvent.class);
+            eventRepository.getObject().save(casEvent);
+            return ResponseEntity.ok().build();
+        }
     }
 
     private ResponseEntity<CasEvent> importEventsAsStream(final HttpServletRequest request) throws Throwable {

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/executor/EncryptedTranscoder.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/executor/EncryptedTranscoder.java
@@ -50,16 +50,17 @@ public class EncryptedTranscoder implements Transcoder {
         if (o == null) {
             return ArrayUtils.EMPTY_BYTE_ARRAY;
         }
-        val outBuffer = new ByteArrayOutputStream();
-        try (val out = this.compression
-            ? new ObjectOutputStream(new GZIPOutputStream(outBuffer))
-            : new ObjectOutputStream(outBuffer)) {
+        try (val outBuffer = new ByteArrayOutputStream();
+             val out = this.compression
+                 ? new ObjectOutputStream(new GZIPOutputStream(outBuffer))
+                 : new ObjectOutputStream(outBuffer)) {
 
             writeObjectToOutputStream(o, out);
+            return encrypt(outBuffer);
         } catch (final NotSerializableException e) {
             LoggingUtils.warn(LOGGER, e);
+            return ArrayUtils.EMPTY_BYTE_ARRAY;
         }
-        return encrypt(outBuffer);
     }
 
     @Override

--- a/docs/cas-server-documentation/authentication/OIDC-Authentication-Identity-Assurance.md
+++ b/docs/cas-server-documentation/authentication/OIDC-Authentication-Identity-Assurance.md
@@ -117,7 +117,7 @@ payload might be:
 
 If you wish to design your own source of identity assurance verifications, you
 may plug in a custom implementation of the `AssuranceVerificationSource` that
-allows you to handle this on on your own:
+allows you to handle this on your own:
 
 ```java
 @Bean

--- a/docs/cas-server-documentation/installation/Logout-Single-Signout.md
+++ b/docs/cas-server-documentation/installation/Logout-Single-Signout.md
@@ -106,7 +106,7 @@ Logout requests may be optionally routed to an external URL bypassing the CAS lo
 
 Registered applications with CAS have the option to control single logout behavior individually via
 the [Service Management](../services/Service-Management.html) component. Each registered service in the service registry will include configuration
-that describes how to the logout request should be submitted. This behavior is controlled via the `logoutType` property
+that describes how the logout request should be submitted. This behavior is controlled via the `logoutType` property
 which allows one to specify whether the logout request should be submitted via back/front channel or turned off for this application.
 
 Sample configuration follows:

--- a/docs/cas-server-documentation/integration/Delegate-Authentication-AuthenticationPolicy.md
+++ b/docs/cas-server-documentation/integration/Delegate-Authentication-AuthenticationPolicy.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: CAS - Delegate Authentication Authentication Policy
+title: CAS - Delegate Authentication Policy
 category: Authentication
 ---
 

--- a/docs/cas-server-documentation/mfa/DuoSecurity-Authentication.md
+++ b/docs/cas-server-documentation/mfa/DuoSecurity-Authentication.md
@@ -72,10 +72,10 @@ response from Duo Security is passed to CAS as a browser redirect
 and CAS will begin to negotiate and exchange that response in favor of
 a JWT that contains the multifactor authentication user profile details.
 
-Universal Prompt no longer requires you to generate and use a application
+Universal Prompt no longer requires you to generate and use an application
 key value. Instead, it requires a *client id* and *client secret*, which
 are known and taught CAS using the integration key and secret key
-configuration settings. You will need get your integration key, secret key, and API
+configuration settings. You will need to get your integration key, secret key, and API
 hostname from Duo Security when you register CAS as a protected application.
  
 ## Non-Browser MFA

--- a/docs/cas-server-documentation/services/Configuring-Service-Replication.md
+++ b/docs/cas-server-documentation/services/Configuring-Service-Replication.md
@@ -16,7 +16,7 @@ the following mechanisms may be used to copy files from one host to another.
 
 ## Native
 
-A background task can be scheduled with the likes of `rsync` to copy files from host to another. 
+A background task can be scheduled with the likes of `rsync` to copy files from one host to another.
 The job needs to of course run periodically to ensure configuration is kept in sync. 
 This is the simplest option as CAS is completely ignorant of extra process in the background.
 

--- a/docs/cas-server-documentation/webflow/Webflow-Customization-Interrupt-Tracking.md
+++ b/docs/cas-server-documentation/webflow/Webflow-Customization-Interrupt-Tracking.md
@@ -29,7 +29,7 @@ overall size of the cookie accepted by the browser or the server container of ch
  
 If you wish to design your own interrupt tracking mechanism, you
 may plug in a custom implementation of the `InterruptTrackingEngine` that
-allows you to handle this on on your own:
+allows you to handle this on your own:
                 
 ```java
 @Bean

--- a/support/cas-server-support-oauth-api/src/main/java/org/apereo/cas/ticket/device/OAuth20DeviceUserCodeFactory.java
+++ b/support/cas-server-support-oauth-api/src/main/java/org/apereo/cas/ticket/device/OAuth20DeviceUserCodeFactory.java
@@ -12,7 +12,7 @@ import org.apereo.cas.ticket.TicketFactory;
 public interface OAuth20DeviceUserCodeFactory extends TicketFactory {
 
     /**
-     * Create device user.
+     * Create OAuth 2.0 device user code.
      *
      * @param service the service
      * @return the device user code
@@ -22,11 +22,11 @@ public interface OAuth20DeviceUserCodeFactory extends TicketFactory {
     }
 
     /**
-     * Create device user code oauth device user code.
+     * Create OAuth 2.0 device user code.
      *
      * @param id      the id
      * @param service the service
-     * @return the oauth device user code
+     * @return the OAuth device user code
      */
     OAuth20DeviceUserCode createDeviceUserCode(String id, Service service);
 

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/OidcJsonWebKeyStoreUtils.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/jwks/OidcJsonWebKeyStoreUtils.java
@@ -150,7 +150,10 @@ public class OidcJsonWebKeyStoreUtils {
                                                               final Optional<String> keyId,
                                                               final Optional<OidcJsonWebKeyUsage> usage) throws Exception {
         LOGGER.debug("Loading JSON web key from [{}]", resource);
-        val json = IOUtils.toString(resource.getInputStream(), StandardCharsets.UTF_8);
+        String json;
+        try (var in = resource.getInputStream()) {
+            json = IOUtils.toString(in, StandardCharsets.UTF_8);
+        }
         LOGGER.debug("Retrieved JSON web key from [{}] as [{}]", resource, json);
         return buildJsonWebKeySet(json, keyId, usage);
     }

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/dynareg/OidcClientRegistrationUtils.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/dynareg/OidcClientRegistrationUtils.java
@@ -84,7 +84,10 @@ public class OidcClientRegistrationUtils {
                 clientResponse.setJwksUri(keystore);
             } else if (ResourceUtils.doesResourceExist(keystore)) {
                 val res = ResourceUtils.getResourceFrom(keystore);
-                val json = IOUtils.toString(res.getInputStream(), StandardCharsets.UTF_8);
+                String json;
+                try (var in = res.getInputStream()) {
+                    json = IOUtils.toString(in, StandardCharsets.UTF_8);
+                }
                 clientResponse.setJwks(new JsonWebKeySet(json).toJson());
             } else if (StringUtils.isNotBlank(keystore)) {
                 val jwks = new JsonWebKeySet(keystore);

--- a/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/jwks/OidcJwksEndpointController.java
+++ b/support/cas-server-support-oidc-core-api/src/main/java/org/apereo/cas/oidc/web/controllers/jwks/OidcJwksEndpointController.java
@@ -73,7 +73,10 @@ public class OidcJwksEndpointController extends BaseOidcController {
         }
         try {
             val resource = oidcJsonWebKeystoreGeneratorService.generate();
-            val jsonJwks = IOUtils.toString(resource.getInputStream(), StandardCharsets.UTF_8);
+            String jsonJwks;
+            try (var in = resource.getInputStream()) {
+                jsonJwks = IOUtils.toString(in, StandardCharsets.UTF_8);
+            }
             val jsonWebKeySet = new JsonWebKeySet(jsonJwks);
 
             val servicesManager = getConfigurationContext().getServicesManager();

--- a/support/cas-server-support-palantir/src/main/java/org/apereo/cas/palantir/controller/DashboardController.java
+++ b/support/cas-server-support-palantir/src/main/java/org/apereo/cas/palantir/controller/DashboardController.java
@@ -83,10 +83,12 @@ public class DashboardController {
         val resources = resolver.getResources("classpath:service-definitions/**/*.json");
 
         for (val resource : resources) {
-            val contents = new String(FileCopyUtils.copyToByteArray(resource.getInputStream()), StandardCharsets.UTF_8);
-            val definition = serializer.from(contents);
-            if (definition != null) {
-                jsonFilesMap.computeIfAbsent(definition.getFriendlyName(), __ -> new ArrayList<>()).add(contents);
+            try (val input = resource.getInputStream()) {
+                val contents = new String(FileCopyUtils.copyToByteArray(input), StandardCharsets.UTF_8);
+                val definition = serializer.from(contents);
+                if (definition != null) {
+                    jsonFilesMap.computeIfAbsent(definition.getFriendlyName(), __ -> new ArrayList<>()).add(contents);
+                }
             }
         }
         return jsonFilesMap;


### PR DESCRIPTION
## Summary
- close InputStreams when reading OIDC keystores
- fix service replication and Duo Security docs
- remove duplicate word from delegated auth policy title

## Testing
- `./gradlew :support:cas-server-support-oidc-core-api:compileJava --offline` *(fails: No cached version... available for offline mode)*