### PR TITLE
Fix documentation typo

### DIFF
--- a/docs/cas-server-documentation/services/JSON-Service-Management.md
+++ b/docs/cas-server-documentation/services/JSON-Service-Management.md
@@ -40,7 +40,7 @@ The JSON service registry is also able to auto detect changes to the specified d
 file additions, removals and updates and will auto-refresh CAS so changes do happen instantly.
 
 <div class="alert alert-info">:information_source: <strong>Escaping Characters</strong><p>
-Please make sure all field values in the JSON blob are correctly escaped, specially for the service id. If the service is defined as a 
+Please make sure all field values in the JSON blob are correctly escaped, especially for the service id. If the service is defined as a
 regular expression, certain regex constructs such as <code>.</code> and <code>\d</code> need to be doubly escaped.
 </p></div>
 

--- a/docs/cas-server-documentation/services/YAML-Service-Management.md
+++ b/docs/cas-server-documentation/services/YAML-Service-Management.md
@@ -48,7 +48,7 @@ The service registry is also able to auto detect changes to the specified direct
 file additions, removals and updates and will auto-refresh CAS so changes do happen instantly.
 
 <div class="alert alert-info">:information_source: <strong>Escaping Characters</strong><p>
-Please make sure all field values in the blob are correctly escaped, specially for the service id. If the service is defined as a regular expression, certain regex constructs such as "." and "\d" need to be doubly escaped.
+Please make sure all field values in the blob are correctly escaped, especially for the service id. If the service is defined as a regular expression, certain regex constructs such as "." and "\d" need to be doubly escaped.
 </p></div>
 
 


### PR DESCRIPTION
## Summary
- fix typo in YAML and JSON service management documentation

## Testing
- `pre-commit` *(fails: This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.)*