### PR TITLE
Fix grammar in documentation

### DIFF
--- a/docs/cas-server-documentation/developer/Build-Process.md
+++ b/docs/cas-server-documentation/developer/Build-Process.md
@@ -168,7 +168,7 @@ need to restart IDEA in order for changes to take full effect.
 ![image](https://user-images.githubusercontent.com/1205228/35231112-287f625a-ffad-11e7-8c1a-af23ff33918d.png)
 
 Note that the CAS-provided Checkstyle rules can be imported into idea to automate a number of 
-formatting rules specially related to package imports and layouts. Once imported, the rules
+formatting rules specifically related to package imports and layouts. Once imported, the rules
 should look something like the below screenshot:
 
 ![image](https://user-images.githubusercontent.com/1205228/42846621-b99539fc-8a2e-11e8-8128-9344bda7224d.png)

--- a/docs/cas-server-documentation/developer/Contributor-Guidelines.md
+++ b/docs/cas-server-documentation/developer/Contributor-Guidelines.md
@@ -218,7 +218,7 @@ No. There are no plans.
 CAS project development activity is largely based on **volunteer time and contributions**. Officially,
 there are no contracts, commitments, timelines, schedules, or funding to plan for changes. Planning for
 future changes and roadmap discussions in the absence of a time commitment, solid funding or sponsorship
-seems unnecessary and can only feel like ceremonial, premature busywork specially as due dates for such
+seems unnecessary and can only feel like ceremonial, premature busywork especially as due dates for such
 plans inevitably and almost always get pushed back and continue to eat dust given the absence of tooling
 and resources. CAS open-source development is never done in vacuums. Generally speaking, work items are
 done when contributors propose, discuss and **show up with pull requests** or when **funding and sponsorship**


### PR DESCRIPTION
## Summary
- correct "specially" to "especially" in Contributor Guidelines
- correct "specially" to "specifically" in Build Process documentation

## Testing
- `git status --short`
