### PR TITLE
Fix typos in docs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,16 +6,16 @@ When you publish the pull request, please check off relevant items below in the 
 
 Please make sure you include the following:
 
-- [] Brief description of changes applied
-- [] Test cases for all modified changes, where applicable
-- [] The same pull request targeted at the master branch, if applicable
-- [] Any documentation on how to configure, test
-- [] Any possible limitations, side effects, etc
-- [] Reference any other pull requests that might be related
+- [ ] Brief description of changes applied
+- [ ] Test cases for all modified changes, where applicable
+- [ ] The same pull request targeted at the master branch, if applicable
+- [ ] Any documentation on how to configure, test
+- [ ] Any possible limitations, side effects, etc
+- [ ] Reference any other pull requests that might be related
 
 For more information, please see [this page](https://apereo.github.io/cas/developer/Contributor-Guidelines.html).
 
-If your pull request targets a maintenance branch and is not directed at `master`, make sure your reference the pull request that
+If your pull request targets a maintenance branch and is not directed at `master`, make sure you reference the pull request that
 has already ported your changes forward to the `master` branch. You may do so by including the following in your pull request description:
 
 ```

--- a/docs/cas-server-documentation/installation/GraalVM-NativeImage-Installation.md
+++ b/docs/cas-server-documentation/installation/GraalVM-NativeImage-Installation.md
@@ -56,7 +56,7 @@ Needless to say, the ability to work with Graal VM native image is and will only
 that run with an [embedded server container](../installation/Configuring-Servlet-Container-Embedded.html).
 When building a CAS Graal VM native image, an embedded server container will be automatically provided.
  
-The build machine that ultimately produces the CAS Graal VM native image is preferred be running Linux 
+The build machine that ultimately produces the CAS Graal VM native image should preferably run Linux
 with at least 32GB of memory and 4 CPU cores.
 
 <div class="alert alert-info">:information_source: <strong>LLVM Toolchain</strong><p>

--- a/docs/cas-server-documentation/installation/Troubleshooting-Guide.md
+++ b/docs/cas-server-documentation/installation/Troubleshooting-Guide.md
@@ -29,8 +29,8 @@ Note that the above configuration block only addresses logging behavior of CAS c
 upon which CAS depends. Consult the log4j configuration and turn on appropriate `DEBUG` logs for each relevant component.
 Those are usually your best data source for diagnostics and troubleshooting.
 
-If your container of choice is [Apache Tomcat](https://tomcat.apache.org/tomcat-11.0-doc/logging.html), 
-you may also want to look into your `catalina.out` and `localhost-X-Y-Z.log` log files to learn more about source of issues. 
+If your container of choice is [Apache Tomcat](https://tomcat.apache.org/tomcat-11.0-doc/logging.html),
+you may also want to look into your `catalina.out` and `localhost-X-Y-Z.log` files to learn more about the source of issues.
 
 ## Deployment Problem; Configuration Issue X. Can You Help?
 
@@ -81,7 +81,7 @@ For [Apache Tomcat](https://tomcat.apache.org/tomcat-11.0-doc/config/http.html),
 
 ## Application X "redirected you too many times" 
 
-"Too many redirect" errors are usually cause by service ticket validation failure events, generally 
+"Too many redirect" errors are usually caused by service ticket validation failure events, generally
 caused by application misconfiguration. 
 Ticket validation failure may be caused by expired or unrecognized tickets, SSL-related 
 issues and such. Examine your CAS logs and you will find the cause.
@@ -110,7 +110,7 @@ Please [review this guide](../services/Service-Management.html) to better unders
 
 ## Invalid/Expired CAS Tickets
 
-You may experience `INVAILD_TICKET` related errors when attempting to use a CAS ticket whose expiration policy dictates that the ticket 
+You may experience `INVALID_TICKET` related errors when attempting to use a CAS ticket whose expiration policy dictates that the ticket
 has expired. The CAS log should further explain in more detail if the ticket is considered expired, but for diagnostic purposes, 
 you may want to adjust the [ticket expiration policy configuration](../ticketing/Configuring-Ticket-Expiration-Policy.html) to remove and troubleshoot this error.
 

--- a/docs/cas-server-documentation/integration/Attribute-Release-Policy-ReturnEnvironment.md
+++ b/docs/cas-server-documentation/integration/Attribute-Release-Policy-ReturnEnvironment.md
@@ -30,6 +30,6 @@ Return environment info and application profiles to the service.
 }
 ```
       
-The above definition will fetch then environment variable `HOME` and release it as `MY_HOME`. Likewise,
+The above definition will fetch the environment variable `HOME` and release it as `MY_HOME`. Likewise,
 it would fetch the system property `KEY` and release it as `MY_KEY`. Active application profiles 
 are always released under an `applicationProfile` attribute.


### PR DESCRIPTION
## Summary
- clarify instructions in PR template
- fix grammar in GraalVM native image guide
- fix attribute release doc typo

## Testing
- `./gradlew help`
