### PR TITLE
Fix documentation typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ enterprise multilingual identity provider and single sign-on solution for the we
 be a comprehensive platform for your authentication and authorization needs.
 
 CAS is an open and well-documented authentication protocol. The primary implementation of the protocol is an open-source Java server
-component by the same name hosted here, with support for a plethora of additional authentication protocols and features such as SAML2, OpenID Connect, MFA
+component by the same name hosted here, with support for a plethora of additional authentication protocols and features such as SAML2, OpenID Connect, MFA,
 and many more.
 
 ## Contributions

--- a/docs/cas-server-documentation/planning/Getting-Started.md
+++ b/docs/cas-server-documentation/planning/Getting-Started.md
@@ -10,9 +10,9 @@ category: Planning
 
 We want to start by saying thank you for using CAS.
 
-This document provides a high-level guide on how to get started with a CAS server deployment. 
-The sole focus of the guide is describe the process
-that must be followed and adopted by CAS deployers in order to arrive at a successful 
+This document provides a high-level guide on how to get started with a CAS server deployment.
+The sole focus of the guide is to describe the process
+that must be followed and adopted by CAS deployers in order to arrive at a successful
 and sustainable architecture and deployment.
        
 ## Before You Begin

--- a/docs/cas-server-documentation/protocol/CAS-Protocol-V2-Specification.md
+++ b/docs/cas-server-documentation/protocol/CAS-Protocol-V2-Specification.md
@@ -569,7 +569,7 @@ manner performs adequately:
                 <p>CAS login successful.</p>
                 <p>  Click <a xhref="https://portal.yale.edu/Login?ticket=ST-..." mce_href="https://portal.yale.edu/Login?ticket=ST-...">here</a>
                 to access the service you requested.<br />  </p>
-            </noscropt>
+            </noscript>
         </body>
     </html>
 


### PR DESCRIPTION
## Summary
- fix grammar in Getting-Started doc
- fix noscript closing tag in protocol spec
- minor punctuation fix in README

## Testing
- `./gradlew help`
- `./gradlew test -m --no-daemon --dry-run` *(fails: Calculating task graph as no cached configuration is available)*

------
https://chatgpt.com/codex/tasks/task_b_683d69bd42408322bd4d16a85c38ccdc