### PR TITLE
Remove duplicated words in Javadocs

### DIFF
--- a/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/sms/SmsProvidersProperties.java
+++ b/api/cas-server-core-api-configuration-model/src/main/java/org/apereo/cas/configuration/model/support/sms/SmsProvidersProperties.java
@@ -75,7 +75,7 @@ public class SmsProvidersProperties implements CasFeatureModule, Serializable {
     private GroovySmsProperties groovy = new GroovySmsProperties();
 
     /**
-     * Send SMS via via REST.
+     * Send SMS via REST.
      */
     @NestedConfigurationProperty
     private RestfulSmsProperties rest = new RestfulSmsProperties();

--- a/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceServiceTicketExpirationPolicy.java
+++ b/api/cas-server-core-api-services/src/main/java/org/apereo/cas/services/RegisteredServiceServiceTicketExpirationPolicy.java
@@ -17,9 +17,9 @@ import java.io.Serializable;
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
 public interface RegisteredServiceServiceTicketExpirationPolicy extends Serializable {
     /**
-     * Undefined registered service service ticket expiration policy.
+     * Undefined registered service ticket expiration policy.
      *
-     * @return the registered service service ticket expiration policy
+     * @return the registered service ticket expiration policy
      */
     static RegisteredServiceServiceTicketExpirationPolicy undefined() {
         return new RegisteredServiceServiceTicketExpirationPolicy() {

--- a/core/cas-server-core-audit-api/src/main/java/org/apereo/inspektr/audit/spi/support/ObjectToStringResourceResolver.java
+++ b/core/cas-server-core-audit-api/src/main/java/org/apereo/inspektr/audit/spi/support/ObjectToStringResourceResolver.java
@@ -35,7 +35,7 @@ public class ObjectToStringResourceResolver implements AuditResourceResolver {
     }
 
     /**
-     * To resource string string.
+     * To resource string.
      *
      * @param arg the arg
      * @return the string

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/CoreAuthenticationUtils.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/CoreAuthenticationUtils.java
@@ -182,7 +182,7 @@ public class CoreAuthenticationUtils {
     }
 
     /**
-     * Transform principal attributes list into map map.
+     * Transform principal attributes list into map.
      *
      * @param list the list
      * @return the map

--- a/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/handler/support/jaas/JaasAuthenticationHandler.java
+++ b/core/cas-server-core-authentication-api/src/main/java/org/apereo/cas/authentication/handler/support/jaas/JaasAuthenticationHandler.java
@@ -132,7 +132,7 @@ public class JaasAuthenticationHandler extends AbstractUsernamePasswordAuthentic
     }
 
     /**
-     * Authenticate and get principal principal.
+     * Authenticate and get principal.
      *
      * @param credential the credential
      * @return the principal

--- a/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/mfa/trigger/RestEndpointMultifactorAuthenticationTrigger.java
+++ b/core/cas-server-core-authentication-mfa-api/src/main/java/org/apereo/cas/authentication/mfa/trigger/RestEndpointMultifactorAuthenticationTrigger.java
@@ -94,7 +94,7 @@ public class RestEndpointMultifactorAuthenticationTrigger implements Multifactor
      *
      * @param principal       the principal
      * @param resolvedService the resolved service
-     * @return return the rest response, typically the mfa id.
+     * @return the rest response, typically the mfa id.
      * @throws Exception the exception
      */
     protected String callRestEndpointForMultifactor(final Principal principal,

--- a/core/cas-server-core-rest-api/src/main/java/org/apereo/cas/rest/factory/ServiceTicketResourceEntityResponseFactory.java
+++ b/core/cas-server-core-rest-api/src/main/java/org/apereo/cas/rest/factory/ServiceTicketResourceEntityResponseFactory.java
@@ -14,7 +14,7 @@ import org.springframework.http.ResponseEntity;
 public interface ServiceTicketResourceEntityResponseFactory extends Ordered {
 
     /**
-     * Build response response entity.
+     * Build response entity.
      *
      * @param ticketGrantingTicket the ticket granting ticket
      * @param service              the service

--- a/core/cas-server-core-rest-api/src/main/java/org/apereo/cas/rest/factory/UserAuthenticationResourceEntityResponseFactory.java
+++ b/core/cas-server-core-rest-api/src/main/java/org/apereo/cas/rest/factory/UserAuthenticationResourceEntityResponseFactory.java
@@ -16,7 +16,7 @@ import jakarta.servlet.http.HttpServletRequest;
 public interface UserAuthenticationResourceEntityResponseFactory {
 
     /**
-     * Build response response entity.
+     * Build response entity.
      *
      * @param result  the result
      * @param request the request

--- a/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/DefaultTicketDefinitionProperties.java
+++ b/core/cas-server-core-tickets-api/src/main/java/org/apereo/cas/ticket/DefaultTicketDefinitionProperties.java
@@ -43,7 +43,7 @@ public class DefaultTicketDefinitionProperties implements TicketDefinitionProper
     /**
      * If a ticket definition is going to be removed
      * as part of a cascade operation, should this definition
-     * be be excluded from removals allowing the ticket
+     * be excluded from removals allowing the ticket
      * to hang around without its parent?
      */
     private boolean excludeFromCascade;

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/CollectionUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/CollectionUtils.java
@@ -547,7 +547,7 @@ public class CollectionUtils {
     }
 
     /**
-     * Wrap set set.
+     * Wrap set.
      *
      * @param <T>    the type parameter
      * @param source the source

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/RegexUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/RegexUtils.java
@@ -65,7 +65,7 @@ public class RegexUtils {
      * case insensitive.
      *
      * @param pattern the pattern, may not be null.
-     * @return the pattern or or {@link RegexUtils#MATCH_NOTHING_PATTERN}
+     * @return the pattern or {@link RegexUtils#MATCH_NOTHING_PATTERN}
      * if pattern is null or invalid.
      */
     public static Pattern createPattern(final String pattern) {

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/function/FunctionUtils.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/function/FunctionUtils.java
@@ -118,7 +118,7 @@ public class FunctionUtils {
     }
 
     /**
-     * Conditional function function.
+     * Conditional function.
      *
      * @param <T>           the type parameter
      * @param <R>           the type parameter
@@ -331,7 +331,7 @@ public class FunctionUtils {
     }
 
     /**
-     * Default function function.
+     * Default function.
      *
      * @param <T>          the type parameter
      * @param <R>          the type parameter

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/beans/BeanCondition.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/beans/BeanCondition.java
@@ -137,7 +137,7 @@ public interface BeanCondition {
     }
 
     /**
-     * To supplier supplier.
+     * To supplier.
      *
      * @param applicationContext the application context
      * @return the supplier

--- a/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/beans/BeanContainer.java
+++ b/core/cas-server-core-util-api/src/main/java/org/apereo/cas/util/spring/beans/BeanContainer.java
@@ -76,7 +76,7 @@ public interface BeanContainer<T> extends DisposableBean {
     List<T> toList();
 
     /**
-     * To set set.
+     * To set.
      *
      * @return the set
      */

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/authentication/DefaultCasWebflowAuthenticationExceptionHandler.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/authentication/DefaultCasWebflowAuthenticationExceptionHandler.java
@@ -47,7 +47,7 @@ public class DefaultCasWebflowAuthenticationExceptionHandler implements CasWebfl
      * Maps an authentication exception onto a state name equal to the simple class name of the handler errors.
      * with highest precedence. Also sets an ERROR severity message in the
      * message context of the form {@code [messageBundlePrefix][exceptionClassSimpleName]}
-     * for for the first handler
+     * for the first handler
      * error that is configured. If no match is found, {@value CasWebflowExceptionCatalog#UNKNOWN} is returned.
      *
      * @param exception              Authentication error to handle.

--- a/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/resolver/impl/AbstractCasWebflowEventResolver.java
+++ b/core/cas-server-core-webflow-api/src/main/java/org/apereo/cas/web/flow/resolver/impl/AbstractCasWebflowEventResolver.java
@@ -81,7 +81,7 @@ public abstract class AbstractCasWebflowEventResolver implements CasWebflowEvent
     }
 
     /**
-     * New event event.
+     * New event.
      *
      * @param id the id
      * @return the event

--- a/core/cas-server-core/src/main/java/org/apereo/cas/AbstractCentralAuthenticationService.java
+++ b/core/cas-server-core/src/main/java/org/apereo/cas/AbstractCentralAuthenticationService.java
@@ -25,7 +25,7 @@ import java.util.Map;
  * An abstract implementation of the {@link CentralAuthenticationService} that provides access to
  * the needed scaffolding and services that are necessary to CAS, such as ticket registry, service registry, etc.
  * The intention here is to allow extensions to easily benefit from these already-configured components
- * without having to to duplicate them again.
+ * without having to duplicate them again.
  *
  * @author Misagh Moayyed
  * @since 4.2.0

--- a/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/MemcachedUtils.java
+++ b/support/cas-server-support-memcached-core/src/main/java/org/apereo/cas/memcached/MemcachedUtils.java
@@ -28,7 +28,7 @@ import java.util.Collection;
 public class MemcachedUtils {
 
     /**
-     * New transcoder transcoder.
+     * New transcoder.
      *
      * @param memcachedProperties the memcached properties
      * @return the transcoder
@@ -38,7 +38,7 @@ public class MemcachedUtils {
     }
 
     /**
-     * New transcoder transcoder.
+     * New transcoder.
      *
      * @param memcachedProperties     the memcached properties
      * @param kryoSerializableClasses the kryo serializable classes

--- a/support/cas-server-support-saml-core-api/src/main/java/org/apereo/cas/support/saml/util/Saml10ObjectBuilder.java
+++ b/support/cas-server-support-saml-core-api/src/main/java/org/apereo/cas/support/saml/util/Saml10ObjectBuilder.java
@@ -133,7 +133,7 @@ public class Saml10ObjectBuilder extends AbstractSamlObjectBuilder {
     }
 
     /**
-     * New status status.
+     * New status.
      *
      * @param codeValue the code value
      * @return the status

--- a/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/idp/metadata/SamlIdPMetadataResolver.java
+++ b/support/cas-server-support-saml-idp-metadata/src/main/java/org/apereo/cas/support/saml/idp/metadata/SamlIdPMetadataResolver.java
@@ -72,7 +72,7 @@ public class SamlIdPMetadataResolver extends BaseElementMetadataResolver {
      * is always added to calculate and resolve metadata globally as the last step,
      * in case an override is not available.
      *
-     * @param criteria criteria set
+     * @param criteria the criteria set
      * @return list of optional service definitions
      */
     private static List<Optional<SamlRegisteredService>> determineFilteringCriteria(final CriteriaSet criteria) {

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/conditions/SamlProfileSamlConditionsBuilder.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/conditions/SamlProfileSamlConditionsBuilder.java
@@ -40,7 +40,7 @@ public class SamlProfileSamlConditionsBuilder extends AbstractSaml20ObjectBuilde
     }
 
     /**
-     * Build conditions conditions.
+     * Build conditions.
      *
      * @param context the context
      * @return the conditions

--- a/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/enc/SamlIdPObjectEncrypter.java
+++ b/support/cas-server-support-saml-idp-web/src/main/java/org/apereo/cas/support/saml/web/idp/profile/builders/enc/SamlIdPObjectEncrypter.java
@@ -436,7 +436,7 @@ public class SamlIdPObjectEncrypter {
 
 
     /**
-     * Configure key decryption credential credential.
+     * Configure key decryption credential.
      *
      * @param peerEntityId            the peer entity id
      * @param adaptor                 the adaptor

--- a/support/cas-server-support-surrogate-core/src/main/java/org/apereo/cas/authentication/SurrogateAuthenticationPrincipalBuilder.java
+++ b/support/cas-server-support-surrogate-core/src/main/java/org/apereo/cas/authentication/SurrogateAuthenticationPrincipalBuilder.java
@@ -19,7 +19,7 @@ public interface SurrogateAuthenticationPrincipalBuilder {
     String BEAN_NAME = "surrogatePrincipalBuilder";
 
     /**
-     * Build surrogate principal principal.
+     * Build surrogate principal.
      *
      * @param credential         the surrogate
      * @param primaryPrincipal  the primary principal
@@ -30,7 +30,7 @@ public interface SurrogateAuthenticationPrincipalBuilder {
     Principal buildSurrogatePrincipal(Credential credential, Principal primaryPrincipal, RegisteredService registeredService) throws Throwable;
 
     /**
-     * Build surrogate principal principal without a service.
+     * Build surrogate principal without a service.
      *
      * @param credential        the surrogate
      * @param primaryPrincipal the primary principal

--- a/support/cas-server-support-trusted-mfa-dynamodb/src/main/java/org/apereo/cas/trusted/authentication/storage/DynamoDbMultifactorTrustEngineFacilitator.java
+++ b/support/cas-server-support-trusted-mfa-dynamodb/src/main/java/org/apereo/cas/trusted/authentication/storage/DynamoDbMultifactorTrustEngineFacilitator.java
@@ -53,7 +53,7 @@ public record DynamoDbMultifactorTrustEngineFacilitator(DynamoDbTrustedDevicesMu
     }
 
     /**
-     * Build table attribute values map map.
+     * Build table attribute values map.
      *
      * @param record the record
      * @return the map

--- a/support/cas-server-support-wsfederation-webflow/src/main/java/org/apereo/cas/web/flow/WsFederationRequestBuilder.java
+++ b/support/cas-server-support-wsfederation-webflow/src/main/java/org/apereo/cas/web/flow/WsFederationRequestBuilder.java
@@ -53,7 +53,7 @@ public class WsFederationRequestBuilder {
     }
 
     /**
-     * Build authentication request event event.
+     * Build authentication request event.
      *
      * @param context the context
      * @return the event


### PR DESCRIPTION
## Summary
- fix repeated words in Javadoc comments across modules

## Testing
- `grep -R --include=*.java -n "\b([A-Za-z][A-Za-z]*) \1\b" | grep -v "@param" | grep -v "LOGGER" | grep -v "val val" | head`

------
https://chatgpt.com/codex/tasks/task_b_68450f929bdc8322bafdd77fdd3e25db